### PR TITLE
Do not check for case sensitivity in a tight loop

### DIFF
--- a/lib/dentaku/calculator.rb
+++ b/lib/dentaku/calculator.rb
@@ -115,9 +115,16 @@ module Dentaku
       restore = Hash[memory]
 
       if value.nil?
-        FlatHash.from_hash(key_or_hash,
-                           @ignore_nested_hashes).each do |key, val|
-          memory[standardize_case(key.to_s)] = val
+        flattened_hash = FlatHash.from_hash(key_or_hash,
+                                            @ignore_nested_hashes)
+        if case_sensitive
+          flattened_hash.each do |key, val|
+            memory[key.to_s] = val
+          end
+        else
+          flattened_hash.each do |key, val|
+            memory[standardize_case(key.to_s)] = val
+          end
         end
       else
         memory[standardize_case(key_or_hash.to_s)] = value


### PR DESCRIPTION
If case_sensitive is false, we don't need to call standardize_case
at all, rather than having to check this every time in the loop.